### PR TITLE
sharing port_groups for multiple policies of the same local pod selector

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -87,6 +87,7 @@ type localPodSelector struct{}
 type egressIPPod struct{}
 type egressIPNamespace struct{}
 type egressNode struct{}
+type sharedPglocalPodSelector struct{}
 
 var (
 	PodType                               reflect.Type = reflect.TypeOf(&kapi.Pod{})
@@ -108,6 +109,7 @@ var (
 	PeerNamespaceSelectorType             reflect.Type = reflect.TypeOf(&peerNamespaceSelector{})
 	PeerPodSelectorType                   reflect.Type = reflect.TypeOf(&peerPodSelector{})
 	LocalPodSelectorType                  reflect.Type = reflect.TypeOf(&localPodSelector{})
+	SharedPgLocalPodSelectorType          reflect.Type = reflect.TypeOf(&sharedPglocalPodSelector{})
 )
 
 // NewMasterWatchFactory initializes a new watch factory for the master or master+node processes.
@@ -408,7 +410,7 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 			return wf.AddFilteredServiceHandler(namespace, funcs, processExisting)
 		}, nil
 
-	case PeerPodSelectorType, LocalPodSelectorType, PodType, EgressIPPodType:
+	case PeerPodSelectorType, LocalPodSelectorType, PodType, EgressIPPodType, SharedPgLocalPodSelectorType:
 		return func(namespace string, sel labels.Selector,
 			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
 			return wf.AddFilteredPodHandler(namespace, sel, funcs, processExisting)

--- a/go-controller/pkg/libovsdbops/acl.go
+++ b/go-controller/pkg/libovsdbops/acl.go
@@ -54,6 +54,21 @@ func FindACLsWithPredicate(nbClient libovsdbclient.Client, p aclPredicate) ([]*n
 	return acls, err
 }
 
+// FindACLsWithUUID looks up ACLs from the cache equivalent with any given acl
+func FindACLsWithUUID(nbClient libovsdbclient.Client, acls []*nbdb.ACL) ([]*nbdb.ACL, error) {
+	pACL := func(item *nbdb.ACL) bool {
+		for index := range acls {
+			if isEquivalentACL(item, acls[index]) {
+				return true
+			}
+		}
+		return false
+	}
+
+	matchAcls, err := FindACLsWithPredicate(nbClient, pACL)
+	return matchAcls, err
+}
+
 // BuildACL builds an ACL with empty optional properties unset
 func BuildACL(name string, direction nbdb.ACLDirection, priority int, match string, action nbdb.ACLAction, meter string, severity nbdb.ACLSeverity, log bool, externalIds map[string]string, options map[string]string) *nbdb.ACL {
 	name = fmt.Sprintf("%.63s", name)

--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -341,7 +341,8 @@ func hasResourceAnUpdateFunc(objType reflect.Type) bool {
 		factory.EgressIPPodType,
 		factory.EgressNodeType,
 		factory.CloudPrivateIPConfigType,
-		factory.LocalPodSelectorType:
+		factory.LocalPodSelectorType,
+		factory.SharedPgLocalPodSelectorType:
 		return true
 	}
 	return false
@@ -402,7 +403,8 @@ func areResourcesEqual(objType reflect.Type, obj1, obj2 interface{}) (bool, erro
 		factory.EgressIPPodType,
 		factory.PeerPodSelectorType,
 		factory.PeerPodForNamespaceAndPodSelectorType,
-		factory.LocalPodSelectorType:
+		factory.LocalPodSelectorType,
+		factory.SharedPgLocalPodSelectorType:
 		// For these types, there was no old vs new obj comparison in the original update code,
 		// so pretend they're always different so that the update code gets executed
 		return false, nil
@@ -467,7 +469,8 @@ func getResourceKey(objType reflect.Type, obj interface{}) (string, error) {
 		factory.PeerPodSelectorType,
 		factory.PeerPodForNamespaceAndPodSelectorType,
 		factory.LocalPodSelectorType,
-		factory.EgressIPPodType:
+		factory.EgressIPPodType,
+		factory.SharedPgLocalPodSelectorType:
 		pod, ok := obj.(*kapi.Pod)
 		if !ok {
 			return "", fmt.Errorf("could not cast %T object to *kapi.Pod", obj)
@@ -561,7 +564,8 @@ func (oc *Controller) getResourceFromInformerCache(objType reflect.Type, key str
 		factory.PeerPodSelectorType,
 		factory.PeerPodForNamespaceAndPodSelectorType,
 		factory.LocalPodSelectorType,
-		factory.EgressIPPodType:
+		factory.EgressIPPodType,
+		factory.SharedPgLocalPodSelectorType:
 		namespace, name := splitNamespacedName(key)
 		obj, err = oc.watchFactory.GetPod(namespace, name)
 
@@ -799,6 +803,9 @@ func (oc *Controller) addResource(objectsToRetry *retryObjs, obj interface{}, fr
 			extraParameters.portGroupEgressDenyName,
 			obj)
 
+	case factory.SharedPgLocalPodSelectorType:
+		return oc.handleSharedPortGroupLocalPodSelectorAddFunc(objectsToRetry.extraParameters.(*sharedPortGroupInfo), obj)
+
 	case factory.EgressFirewallType:
 		var err error
 		egressFirewall := obj.(*egressfirewall.EgressFirewall).DeepCopy()
@@ -990,6 +997,9 @@ func (oc *Controller) updateResource(objectsToRetry *retryObjs, oldObj, newObj i
 		oldCloudPrivateIPConfig := oldObj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
 		newCloudPrivateIPConfig := newObj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
 		return oc.reconcileCloudPrivateIPConfig(oldCloudPrivateIPConfig, newCloudPrivateIPConfig)
+
+	case factory.SharedPgLocalPodSelectorType:
+		return oc.handleSharedPortGroupLocalPodSelectorAddFunc(objectsToRetry.extraParameters.(*sharedPortGroupInfo), newObj)
 	}
 
 	return fmt.Errorf("no update function for object type %s", objectsToRetry.oType)
@@ -1089,6 +1099,9 @@ func (oc *Controller) deleteResource(objectsToRetry *retryObjs, obj, cachedObj i
 			extraParameters.portGroupIngressDenyName,
 			extraParameters.portGroupEgressDenyName,
 			obj)
+
+	case factory.SharedPgLocalPodSelectorType:
+		return oc.handleSharedPortGroupLocalPodSelectorDelFunc(objectsToRetry.extraParameters.(*sharedPortGroupInfo), obj)
 
 	case factory.EgressFirewallType:
 		egressFirewall := obj.(*egressfirewall.EgressFirewall)
@@ -1369,7 +1382,8 @@ func (oc *Controller) getSyncResourcesFunc(r *retryObjs) (func([]interface{}) er
 			return nil
 		}
 
-	case factory.LocalPodSelectorType:
+	case factory.LocalPodSelectorType,
+		factory.SharedPgLocalPodSelectorType:
 		syncFunc = r.syncFunc
 
 	case factory.EgressFirewallType:
@@ -1401,7 +1415,8 @@ func (oc *Controller) isObjectInTerminalState(objType reflect.Type, obj interfac
 		factory.PeerPodSelectorType,
 		factory.PeerPodForNamespaceAndPodSelectorType,
 		factory.LocalPodSelectorType,
-		factory.EgressIPPodType:
+		factory.EgressIPPodType,
+		factory.SharedPgLocalPodSelectorType:
 		pod := obj.(*kapi.Pod)
 		return util.PodCompleted(pod)
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -57,6 +57,21 @@ type ACLLoggingLevels struct {
 	Deny  string `json:"deny,omitempty"`
 }
 
+type sharedPortGroupInfo struct {
+	sync.Mutex
+	pgName           string
+	aclLogDeny       string
+	aclLogAllow      string
+	policies         map[string]bool // policies sharing this port group
+	lspIngressRefCnt int
+	lspEgressRefCnt  int
+	podHandler       *factory.Handler
+	// localPods is a list of pods affected by ths shared group
+	// this is a sync map so we can handle multiple pods at once
+	// map of string -> *lpInfo
+	localPods sync.Map
+}
+
 // namespaceInfo contains information related to a Namespace. Use oc.getNamespaceLocked()
 // or oc.waitForNamespaceLocked() to get a locked namespaceInfo for a Namespace, and call
 // nsInfo.Unlock() on it when you are done with it. (No code outside of the code that
@@ -127,6 +142,10 @@ type Controller struct {
 
 	externalGWCache map[ktypes.NamespacedName]*externalRouteInfo
 	exGWCacheMutex  sync.RWMutex
+
+	// Info about policy-shared portGroup. key is shared port group name
+	spgInfoMap   map[string]*sharedPortGroupInfo
+	spgInfoMutex sync.Mutex
 
 	// egressFirewalls is a map of namespaces and the egressFirewall attached to it
 	egressFirewalls sync.Map
@@ -321,6 +340,8 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 		svcController:             svcController,
 		svcFactory:                svcFactory,
 		podRecorder:               metrics.NewPodRecorder(),
+		spgInfoMap:                make(map[string]*sharedPortGroupInfo),
+		spgInfoMutex:              sync.Mutex{},
 	}
 }
 

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
 	ovsdb "github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -23,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kerrorsutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -75,19 +77,40 @@ type networkPolicy struct {
 	portGroupName string
 	deleted       bool //deleted policy
 	created       bool
+
+	// only valid for policy that sharing portGroup, if sharePortGroupName is "", it cannot share portGroup
+	sharePortGroupName string
+	ingressDefDeny     bool
+	egressDefDeny      bool
+}
+
+// now we only support portGroup sharing if the policy's local pod selector is empty. This can be changed later.
+func getSharedPortGroupName(policy *knet.NetworkPolicy) string {
+	sel := &policy.Spec.PodSelector
+	if len(sel.MatchLabels) == 0 && len(sel.MatchExpressions) == 0 {
+		// now we only support empty podSelector policy to share the portGroup
+		return policy.Namespace + "_" + "Share_PortGrp"
+	}
+	return ""
 }
 
 func NewNetworkPolicy(policy *knet.NetworkPolicy) *networkPolicy {
+	ingressDefDeny := !(len(policy.Spec.PolicyTypes) == 1 && policy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress)
+	egressDefDeny := (len(policy.Spec.PolicyTypes) == 1 && policy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress) ||
+		len(policy.Spec.Egress) > 0 || len(policy.Spec.PolicyTypes) == 2
 	np := &networkPolicy{
-		name:            policy.Name,
-		namespace:       policy.Namespace,
-		policy:          policy,
-		ingressPolicies: make([]*gressPolicy, 0),
-		egressPolicies:  make([]*gressPolicy, 0),
-		podHandlerList:  make([]*factory.Handler, 0),
-		svcHandlerList:  make([]*factory.Handler, 0),
-		nsHandlerList:   make([]*factory.Handler, 0),
-		localPods:       sync.Map{},
+		name:               policy.Name,
+		namespace:          policy.Namespace,
+		policy:             policy,
+		ingressPolicies:    make([]*gressPolicy, 0),
+		egressPolicies:     make([]*gressPolicy, 0),
+		podHandlerList:     make([]*factory.Handler, 0),
+		svcHandlerList:     make([]*factory.Handler, 0),
+		nsHandlerList:      make([]*factory.Handler, 0),
+		localPods:          sync.Map{},
+		sharePortGroupName: getSharedPortGroupName(policy),
+		ingressDefDeny:     ingressDefDeny,
+		egressDefDeny:      egressDefDeny,
 	}
 	return np
 }
@@ -157,11 +180,35 @@ func (oc *Controller) updateStaleDefaultDenyACLNames(npType knet.PolicyType, gre
 }
 
 func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) error {
+	cleanupSharePortGroupPolicy := false
+	// If version is less than OvnSharePortGroupPolicyVersion, we need to remove
+	// related Acls/PortGroup and let the policy handler add the correct ones back
+	ver, err := oc.determineOVNTopoVersionFromOVN()
+	if err != nil {
+		klog.Errorf("Failed to get current OVN topology ver: %v", err)
+	} else if ver < types.OvnSharePortGroupPolicyVersion {
+		cleanupSharePortGroupPolicy = true
+	}
+	stalePGs := sets.NewString()
 	expectedPolicies := make(map[string]map[string]bool)
 	for _, npInterface := range networkPolicies {
 		policy, ok := npInterface.(*knet.NetworkPolicy)
 		if !ok {
 			return fmt.Errorf("spurious object in syncNetworkPolicies: %v", npInterface)
+		}
+
+		if cleanupSharePortGroupPolicy {
+			if getSharedPortGroupName(policy) != "" {
+				// this policy needs to use shared group PortGroup, as the result, the per-namespace defaultDenyPort
+				// group's ports might also change, delete those and they will be created later.
+				stalePGs.Insert(defaultDenyPortGroup(policy.Namespace, ingressDefaultDenySuffix))
+				stalePGs.Insert(defaultDenyPortGroup(policy.Namespace, egressDefaultDenySuffix))
+				stalePGs.Insert(hashedPortGroup(fmt.Sprintf("%s_%s", policy.Namespace, policy.Name)))
+
+				// this policy's is going to be changed to use shared portGroup. Simply not to add it to
+				//  expectedPolicies, and its associated logical entities will be added later in the policy handler
+				continue
+			}
 		}
 
 		if nsMap, ok := expectedPolicies[policy.Namespace]; ok {
@@ -173,13 +220,12 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) error {
 		}
 	}
 
-	stalePGs := []string{}
-	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, policyName string) error {
+	err = oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, policyName string) error {
 		if policyName != "" && !expectedPolicies[namespaceName][policyName] {
 			// policy doesn't exist on k8s. Delete the port group
 			portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
 			hashedLocalPortGroup := hashedPortGroup(portGroupName)
-			stalePGs = append(stalePGs, hashedLocalPortGroup)
+			stalePGs.Insert(hashedLocalPortGroup)
 			// delete the address sets for this old policy from OVN
 			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
 				klog.Errorf(err.Error())
@@ -192,11 +238,17 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) error {
 		return fmt.Errorf("error in syncing network policies: %v", err)
 	}
 
-	if len(stalePGs) > 0 {
-		err = libovsdbops.DeletePortGroups(oc.nbClient, stalePGs...)
+	ops := []libovsdb.Operation{}
+	for stalePG := range stalePGs {
+		ops, err = libovsdbops.DeletePortGroupsOps(oc.nbClient, ops, stalePG)
 		if err != nil {
-			return fmt.Errorf("error removing stale port groups %v: %v", stalePGs, err)
+			return fmt.Errorf("error getting ops of removing stale port group %v: %v", stalePG, err)
 		}
+	}
+
+	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+	if err != nil {
+		return fmt.Errorf("error removing stale port groups %v: %v", stalePGs, err)
 	}
 
 	// Update existing egress network policies to use the updated ACLs
@@ -250,7 +302,7 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) error {
 		return fmt.Errorf("cannot find stale arp allow ACLs: %v", err)
 	}
 	// Remove these stale ACLs from port groups and then delete them
-	var ops []ovsdb.Operation
+	ops = []ovsdb.Operation{}
 	for _, gressACL := range gressACLs {
 		gressACL := gressACL
 		pgName := ""
@@ -438,7 +490,7 @@ func (oc *Controller) deleteDefaultDenyPGAndACLs(namespace, policy string, nsInf
 	return nil
 }
 
-func (oc *Controller) updateACLLoggingForPolicy(np *networkPolicy, logLevel string) error {
+func (oc *Controller) updateACLLoggingForPolicy(np *networkPolicy, portGroupName, logLevel string) error {
 	np.Lock()
 	defer np.Unlock()
 
@@ -450,7 +502,7 @@ func (oc *Controller) updateACLLoggingForPolicy(np *networkPolicy, logLevel stri
 		return NetworkPolicyNotCreated
 	}
 
-	acls := oc.buildNetworkPolicyACLs(np, logLevel)
+	acls := oc.buildNetworkPolicyACLs(np, portGroupName, logLevel)
 	ops, err := libovsdbops.UpdateACLsLoggingOps(oc.nbClient, nil, acls...)
 	if err != nil {
 		return err
@@ -461,16 +513,44 @@ func (oc *Controller) updateACLLoggingForPolicy(np *networkPolicy, logLevel stri
 
 func (oc *Controller) setNetworkPolicyACLLoggingForNamespace(ns string, nsInfo *namespaceInfo) error {
 	var ovsDBOps []ovsdb.Operation
+	var err error
+
+	oc.spgInfoMutex.Lock()
+	for _, np := range nsInfo.networkPolicies {
+		sharePortGroupName := np.sharePortGroupName
+		spgInfo, ok := oc.spgInfoMap[np.sharePortGroupName]
+		if !ok {
+			continue
+		}
+		spgInfo.aclLogDeny = nsInfo.aclLogging.Deny
+		spgInfo.aclLogAllow = nsInfo.aclLogging.Allow
+		for _, policyType := range []knet.PolicyType{knet.PolicyTypeIngress, knet.PolicyTypeEgress} {
+			var sharedDenyACL *nbdb.ACL
+			sharedDenyACL = nil
+			if policyType == knet.PolicyTypeIngress && spgInfo.lspIngressRefCnt > 0 {
+				sharedDenyACL, _ = buildDenyACLs(sharePortGroupName, ingressDefaultDenySuffix, hashedPortGroup(sharePortGroupName), spgInfo.aclLogDeny, policyType)
+			} else if policyType == knet.PolicyTypeEgress && spgInfo.lspEgressRefCnt > 0 {
+				sharedDenyACL, _ = buildDenyACLs(sharePortGroupName, egressDefaultDenySuffix, hashedPortGroup(sharePortGroupName), spgInfo.aclLogDeny, policyType)
+			}
+			if sharedDenyACL != nil {
+				ovsDBOps, err = libovsdbops.UpdateACLsLoggingOps(oc.nbClient, ovsDBOps, sharedDenyACL)
+				if err != nil {
+					oc.spgInfoMutex.Unlock()
+					return err
+				}
+			}
+		}
+	}
+	oc.spgInfoMutex.Unlock()
 	for _, policyType := range []knet.PolicyType{knet.PolicyTypeIngress, knet.PolicyTypeEgress} {
 		denyACL, _ := buildDenyACLs(ns, "", targetPortGroupName(nsInfo.portGroupIngressDenyName, nsInfo.portGroupEgressDenyName, policyType), nsInfo.aclLogging.Deny, policyType)
-		var err error
 		ovsDBOps, err = libovsdbops.UpdateACLsLoggingOps(oc.nbClient, ovsDBOps, denyACL)
 		if err != nil {
 			return err
 		}
 	}
 
-	if _, err := libovsdbops.TransactAndCheck(oc.nbClient, ovsDBOps); err != nil {
+	if _, err = libovsdbops.TransactAndCheck(oc.nbClient, ovsDBOps); err != nil {
 		return fmt.Errorf("unable to update deny ACL for namespace %s: %w", ns, err)
 	}
 
@@ -482,7 +562,7 @@ func (oc *Controller) setNetworkPolicyACLLoggingForNamespace(ns string, nsInfo *
 		// libovsdb transactions take less than 50ms usually as well so pod create
 		// should be done within a couple iterations
 		retryErr := wait.PollImmediate(24*time.Millisecond, 1*time.Second, func() (bool, error) {
-			if err := oc.updateACLLoggingForPolicy(policy, nsInfo.aclLogging.Allow); err == nil {
+			if err = oc.updateACLLoggingForPolicy(policy, policy.portGroupName, nsInfo.aclLogging.Allow); err == nil {
 				return true, nil
 			} else if errors.Is(err, NetworkPolicyNotCreated) {
 				return false, nil
@@ -1064,6 +1144,382 @@ func hasAnyLabelSelector(peers []knet.NetworkPolicyPeer) bool {
 	return false
 }
 
+func (oc *Controller) processSharedPortGroupLocalPodSelectorSetPods(spgInfo *sharedPortGroupInfo,
+	objs ...interface{}) (policyPorts []string) {
+	klog.Infof("Processing shared networkGroup %s to have %d local pods...", spgInfo.pgName, len(objs))
+
+	// get list of pods and their logical ports to add
+	// theoretically this should never filter any pods but it's always good to be
+	// paranoid.
+	policyPorts = make([]string, 0, len(objs))
+
+	// thread safe helper vars used by the `getPortInfo` go-routine
+	getPortsInfoMap := sync.Map{}
+	getPolicyPortsWg := &sync.WaitGroup{}
+
+	getPortInfo := func(pod *kapi.Pod) {
+		defer getPolicyPortsWg.Done()
+
+		if pod.Spec.NodeName == "" {
+			return
+		}
+
+		// Get the logical port info
+		logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
+		var portInfo *lpInfo
+
+		// Get the logical port info from the cache, if that fails, retry
+		// if the gotten LSP is Scheduled for removal, retry (stateful-sets)
+		//
+		// 24ms is chosen because gomega.Eventually default timeout is 50ms
+		// libovsdb transactions take less than 50ms usually as well so pod create
+		// should be done within a couple iterations
+		retryErr := wait.PollImmediate(24*time.Millisecond, 1*time.Second, func() (bool, error) {
+			var err error
+
+			// Retry if getting pod LSP from the cache fails
+			portInfo, err = oc.logicalPortCache.get(logicalPort)
+			if err != nil {
+				klog.Warningf("Failed to get LSP for pod %s/%s for shared networkGroup %s refetching err: %v", pod.Namespace, pod.Name, spgInfo.pgName, err)
+				return false, nil
+			}
+
+			// Retry if LSP is scheduled for deletion
+			if !portInfo.expires.IsZero() {
+				klog.Warningf("Stale LSP %s for network shared networkGroup %s found in cache refetching", portInfo.name, spgInfo.pgName)
+				return false, nil
+			}
+
+			// LSP get succeeded and LSP is up to fresh, exit and continue
+			klog.V(5).Infof("Fresh LSP %s for shared networkGroup %s found in cache", portInfo.name, spgInfo.pgName)
+			return true, nil
+		})
+		if retryErr != nil {
+			// Failed to get an up to date version of the LSP from the cache
+			klog.Warning("Failed to get LSP after multiple retries for pod %s/%s for shared networkGroup %s err: %v", pod.Namespace, pod.Name, spgInfo.pgName, retryErr)
+			return
+		}
+
+		// if this pod is somehow already added to this policy, then skip
+		if _, ok := spgInfo.localPods.LoadOrStore(portInfo.name, portInfo); ok {
+			return
+		}
+
+		getPortsInfoMap.Store(portInfo.uuid, portInfo)
+	}
+	for _, obj := range objs {
+		pod := obj.(*kapi.Pod)
+
+		if util.PodCompleted(pod) {
+			// if pod is completed, do not add it to NP port group
+			continue
+		}
+
+		getPolicyPortsWg.Add(1)
+		go getPortInfo(pod)
+	}
+	getPolicyPortsWg.Wait()
+
+	getPortsInfoMap.Range(func(key interface{}, value interface{}) bool {
+		policyPorts = append(policyPorts, key.(string))
+		return true
+	})
+
+	return
+}
+
+func (oc *Controller) processSharedPortGroupLocalPodSelectorDelPods(spgInfo *sharedPortGroupInfo,
+	objs ...interface{}) (policyPorts []string) {
+	klog.Infof("Processing shared networkGroup %s  to delete %d local pods...", spgInfo.pgName, len(objs))
+	policyPorts = make([]string, 0, len(objs))
+	for _, obj := range objs {
+		pod := obj.(*kapi.Pod)
+
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+
+		// Get the logical port info
+		logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
+		portInfo, err := oc.logicalPortCache.get(logicalPort)
+		// pod is not yet handled
+		// no big deal, we'll get the update when it is.
+		if err != nil {
+			klog.Errorf(err.Error())
+			return
+		}
+
+		// If we never saw this pod, short-circuit
+		if _, ok := spgInfo.localPods.LoadAndDelete(logicalPort); !ok {
+			continue
+		}
+
+		policyPorts = append(policyPorts, portInfo.uuid)
+	}
+
+	return
+}
+
+// handleSharedPortGroupLocalPodSelectorAddFunc adds new pods to an existing shared group
+func (oc *Controller) handleSharedPortGroupLocalPodSelectorAddFunc(spgInfo *sharedPortGroupInfo, obj interface{}) error {
+	policyPorts := oc.processSharedPortGroupLocalPodSelectorSetPods(spgInfo, obj)
+
+	klog.V(5).Infof("Add ports %v to portGroup %s", policyPorts, spgInfo.pgName)
+	err := libovsdbops.AddPortsToPortGroup(oc.nbClient, spgInfo.pgName, policyPorts...)
+	if err != nil {
+		return fmt.Errorf("failed to add ports %v to portgroup %s: %v", policyPorts, spgInfo.pgName, err)
+	}
+	return nil
+}
+
+// handleSharedPortGroupLocalPodSelectorDelFunc delete a removed pod to an existing NetworkPolicy
+func (oc *Controller) handleSharedPortGroupLocalPodSelectorDelFunc(spgInfo *sharedPortGroupInfo, obj interface{}) error {
+	policyPorts := oc.processSharedPortGroupLocalPodSelectorDelPods(spgInfo, obj)
+	err := libovsdbops.DeletePortsFromPortGroup(oc.nbClient, spgInfo.pgName, policyPorts...)
+	if err != nil {
+		return fmt.Errorf("failed to delete ports %v from portgroup %s: %v", policyPorts, spgInfo.pgName, err)
+	}
+	return nil
+}
+
+func (oc *Controller) createSharedNMPortGroup(policy *knet.NetworkPolicy, np *networkPolicy) (*sharedPortGroupInfo, error) {
+	klog.Infof("Create shared portGroup %s", np.sharePortGroupName)
+
+	// create shared portGroup
+	pgName := np.sharePortGroupName
+	pgHashName := hashedPortGroup(pgName)
+	ingressPG := libovsdbops.BuildPortGroup(pgHashName, pgName, nil, nil)
+
+	spgInfo := &sharedPortGroupInfo{
+		pgName:           pgHashName,
+		lspIngressRefCnt: 0,
+		lspEgressRefCnt:  0,
+		podHandler:       nil,
+		localPods:        sync.Map{},
+		policies:         map[string]bool{},
+	}
+	var selectedPods []interface{}
+	handleSharedPortGroupInitialSelectedPods := func(objs []interface{}) error {
+		selectedPods = objs
+		policyPorts := oc.processSharedPortGroupLocalPodSelectorSetPods(spgInfo, selectedPods...)
+		ingressPG.Ports = policyPorts
+		err := libovsdbops.CreateOrUpdatePortGroups(oc.nbClient, ingressPG)
+		if err != nil {
+			return fmt.Errorf("failed to create port group %s: %v", ingressPG.Name, err)
+		}
+		return nil
+	}
+	// NetworkPolicy is validated by the apiserver
+	sel, err := metav1.LabelSelectorAsSelector(&policy.Spec.PodSelector)
+	if err != nil {
+		klog.Errorf("Could not set up watcher for local pods: %v", err)
+		return nil, err
+	}
+
+	retryLocalPods := NewRetryObjs(
+		factory.SharedPgLocalPodSelectorType,
+		policy.Namespace,
+		sel,
+		handleSharedPortGroupInitialSelectedPods,
+		spgInfo,
+	)
+
+	podHandler, err := oc.WatchResource(retryLocalPods)
+	if err != nil {
+		klog.Errorf("Failed WatchResource for handleLocalPodSelector: %v", err)
+		return nil, err
+	}
+
+	spgInfo.podHandler = podHandler
+	return spgInfo, nil
+}
+
+func (oc *Controller) deleteSharedNMPortGroup(np *networkPolicy, spgInfo *sharedPortGroupInfo, ops []libovsdb.Operation) ([]libovsdb.Operation, error) {
+	klog.V(5).Infof("Delete shared portGroup for %s", np.sharePortGroupName)
+
+	pgName := spgInfo.pgName
+
+	// delete shared portgroup
+	var err error
+	ops, err = libovsdbops.DeletePortGroupsOps(oc.nbClient, ops, pgName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete shared portgroup ops for %s, error: %v", np.sharePortGroupName, err)
+	}
+
+	return ops, nil
+}
+
+func (oc *Controller) createSharedPolicy(np *networkPolicy, policy *knet.NetworkPolicy, aclLogDeny, aclLogAllow string) (err error) {
+	klog.Infof("Policy %s/%s to be added to shared portGroup", np.namespace, np.name)
+	// create shared portGroup
+	oc.spgInfoMutex.Lock()
+	spgInfo, ok := oc.spgInfoMap[np.sharePortGroupName]
+	if !ok {
+		spgInfo, err = oc.createSharedNMPortGroup(policy, np)
+		if err != nil {
+			oc.spgInfoMutex.Unlock()
+			return err
+		}
+		// policy of the same shared port group must be in the same namespace, which share the same aclLogLevel
+		spgInfo.aclLogAllow = aclLogAllow
+		spgInfo.aclLogDeny = aclLogDeny
+		oc.spgInfoMap[np.sharePortGroupName] = spgInfo
+	}
+	spgInfo.Lock()
+	oc.spgInfoMutex.Unlock()
+
+	defer spgInfo.Unlock()
+	_, ok = spgInfo.policies[getPolicyNamespacedName(policy)]
+	if ok {
+		return nil
+	}
+
+	np.portGroupName = spgInfo.pgName
+	acls := []*nbdb.ACL{}
+	if np.ingressDefDeny {
+		if spgInfo.lspIngressRefCnt == 0 {
+			ingressDenyACL, ingressAllowACL := buildDenyACLs(np.sharePortGroupName, ingressDefaultDenySuffix, np.portGroupName, spgInfo.aclLogDeny, knet.PolicyTypeIngress)
+			acls = append(acls, ingressDenyACL)
+			acls = append(acls, ingressAllowACL)
+
+		}
+	}
+	if np.egressDefDeny {
+		if spgInfo.lspEgressRefCnt == 0 {
+			egressDenyACL, egressAllowACL := buildDenyACLs(np.sharePortGroupName, egressDefaultDenySuffix, np.portGroupName, spgInfo.aclLogDeny, knet.PolicyTypeEgress)
+			acls = append(acls, egressDenyACL)
+			acls = append(acls, egressAllowACL)
+		}
+	}
+
+	defer func() {
+		if err == nil {
+			if np.ingressDefDeny {
+				spgInfo.lspIngressRefCnt++
+			}
+			if np.egressDefDeny {
+				spgInfo.lspEgressRefCnt++
+			}
+			spgInfo.policies[getPolicyNamespacedName(policy)] = true
+		}
+	}()
+
+	if len(acls) == 0 {
+		return nil
+	}
+
+	klog.Infof("Creating default deny acls %+v for network policy %s/%s shared portGroup",
+		acls, np.namespace, np.name)
+	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, acls...)
+	if err != nil {
+		return err
+	}
+
+	ops, err = libovsdbops.AddACLsToPortGroupOps(oc.nbClient, ops, np.portGroupName, acls...)
+	if err != nil {
+		return err
+	}
+	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (oc *Controller) deleteSharedPolicy(np *networkPolicy) error {
+	var err error
+	klog.V(5).Infof("Policy %s/%s to be removed from shared portGroup %s", np.namespace, np.name, np.sharePortGroupName)
+
+	// delete shared portGroup
+	oc.spgInfoMutex.Lock()
+	spgInfo, ok := oc.spgInfoMap[np.sharePortGroupName]
+	if !ok {
+		oc.spgInfoMutex.Unlock()
+		return nil
+	}
+	spgInfo.Lock()
+	oc.spgInfoMutex.Unlock()
+	defer spgInfo.Unlock()
+
+	// check if this is the last policy sharing this port group
+	expectedLastPolicyNum := 0
+	_, ok = spgInfo.policies[getNPNamespacedName(np)]
+	if ok {
+		expectedLastPolicyNum = 1
+	}
+	ops := []libovsdb.Operation{}
+	isLastPolicyInSharedGroup := len(spgInfo.policies) == expectedLastPolicyNum
+	if isLastPolicyInSharedGroup {
+		ops, err = oc.deleteSharedNMPortGroup(np, spgInfo, ops)
+		if err != nil {
+			return err
+		}
+	}
+
+	if ok {
+		acls := []*nbdb.ACL{}
+		// delete shared portGroup if this is the last policy sharing the perNamespace portGroup
+		if np.ingressDefDeny {
+			if spgInfo.lspIngressRefCnt == 1 {
+				ingressDenyACL, ingressAllowACL := buildDenyACLs(np.sharePortGroupName, ingressDefaultDenySuffix, np.portGroupName, spgInfo.aclLogDeny, knet.PolicyTypeIngress)
+				acls = append(acls, ingressDenyACL)
+				acls = append(acls, ingressAllowACL)
+			} else if spgInfo.lspIngressRefCnt <= 0 {
+				return fmt.Errorf("unexpected ingress refCount number sharing portGroup %s", np.sharePortGroupName)
+			}
+		}
+		if np.egressDefDeny {
+			if spgInfo.lspEgressRefCnt == 1 {
+				egressDenyACL, egressAllowACL := buildDenyACLs(np.sharePortGroupName, egressDefaultDenySuffix, np.portGroupName, spgInfo.aclLogDeny, knet.PolicyTypeEgress)
+				acls = append(acls, egressDenyACL)
+				acls = append(acls, egressAllowACL)
+			} else if spgInfo.lspEgressRefCnt <= 0 {
+				klog.Errorf("Unexpected egress refCount number sharing portGroup %s", np.sharePortGroupName)
+			}
+		}
+
+		if np.created {
+			localAcls := oc.buildNetworkPolicyACLs(np, spgInfo.pgName, spgInfo.aclLogAllow)
+			acls = append(acls, localAcls...)
+		}
+		klog.V(5).Infof("Destroying acls %+v for network policy %s/%s sharing portGroup %s",
+			acls, np.namespace, np.name, np.sharePortGroupName)
+
+		matchAcls, err := libovsdbops.FindACLsWithUUID(oc.nbClient, acls)
+		if err != nil {
+			return fmt.Errorf("failed to find acls %+v for network policy %s/%s sharing portGroup %s: %v",
+				acls, np.namespace, np.name, np.sharePortGroupName, err.Error())
+		}
+		ops, err = libovsdbops.DeleteACLsOps(oc.nbClient, ops, []string{spgInfo.pgName}, nil, matchAcls...)
+		if err != nil {
+			return fmt.Errorf("failed to make ops for remove acls %+v: %v", matchAcls, err.Error())
+		}
+
+		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("failed to execute ovsdb txn to delete network policy: %s/%s, error: %v",
+				np.namespace, np.name, err)
+		}
+		if np.ingressDefDeny {
+			spgInfo.lspIngressRefCnt--
+		}
+		if np.egressDefDeny {
+			spgInfo.lspEgressRefCnt--
+		}
+		delete(spgInfo.policies, getNPNamespacedName(np))
+	}
+	if isLastPolicyInSharedGroup {
+		if spgInfo.podHandler != nil {
+			oc.watchFactory.RemovePodHandler(spgInfo.podHandler)
+			spgInfo.podHandler = nil
+		}
+
+		delete(oc.spgInfoMap, np.sharePortGroupName)
+	}
+
+	return nil
+}
+
 // createNetworkPolicy creates a network policy
 func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.NetworkPolicy, aclLogDeny, aclLogAllow,
 	portGroupIngressDenyName, portGroupEgressDenyName string) error {
@@ -1179,12 +1635,43 @@ func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.Networ
 		}
 	}
 
+	if np.sharePortGroupName != "" {
+		err := oc.createSharedPolicy(np, policy, aclLogDeny, aclLogAllow)
+		if err != nil {
+			return fmt.Errorf("failed to create shared portGroup for policy %s/%s: %v", np.namespace, np.name, err)
+		}
+
+		np.Lock()
+		defer np.Unlock()
+		if np.deleted {
+			return nil
+		}
+		acls := oc.buildNetworkPolicyACLs(np, np.portGroupName, aclLogAllow)
+		klog.Infof("Creating local policy acls %+v for network policy %s/%s sharing portGroup %s",
+			acls, np.namespace, np.name, np.sharePortGroupName)
+		ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, acls...)
+		if err != nil {
+			return fmt.Errorf("failed to create local acls ops for network policy %s/%s: %v", np.namespace, np.name, err)
+		}
+
+		ops, err = libovsdbops.AddACLsToPortGroupOps(oc.nbClient, ops, np.portGroupName, acls...)
+		if err != nil {
+			return fmt.Errorf("failed to add local acls ops to portGroup %s for network policy %s/%s: %v", np.portGroupName, np.namespace, np.name, err)
+		}
+		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("failed to add local acls to portGroup %s for network policy %s/%s: %v", np.portGroupName, np.namespace, np.name, err)
+		}
+		np.created = true
+		return nil
+	}
+
 	readableGroupName := fmt.Sprintf("%s_%s", policy.Namespace, policy.Name)
 	np.portGroupName = hashedPortGroup(readableGroupName)
 	ops := []ovsdb.Operation{}
 
 	// Build policy ACLs
-	acls := oc.buildNetworkPolicyACLs(np, aclLogAllow)
+	acls := oc.buildNetworkPolicyACLs(np, np.portGroupName, aclLogAllow)
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, ops, acls...)
 	if err != nil {
 		return fmt.Errorf("failed to create ACL ops: %v", err)
@@ -1307,8 +1794,9 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 	portGroupIngressDenyName := nsInfo.portGroupIngressDenyName
 	portGroupEgressDenyName := nsInfo.portGroupEgressDenyName
 	nsUnlock()
-	if err := oc.createNetworkPolicy(np, policy, aclLogDeny, aclLogAllow,
-		portGroupIngressDenyName, portGroupEgressDenyName); err != nil {
+	err = oc.createNetworkPolicy(np, policy, aclLogDeny, aclLogAllow,
+		portGroupIngressDenyName, portGroupEgressDenyName)
+	if err != nil {
 		return fmt.Errorf("failed to create Network Policy: %s/%s, error: %v",
 			policy.Namespace, policy.Name, err)
 	}
@@ -1335,7 +1823,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 	// applies to the default deny ACLS which were created while the namespace
 	// was locked.
 	if nsInfo.aclLogging.Allow != aclLogAllow {
-		if err := oc.updateACLLoggingForPolicy(np, nsInfo.aclLogging.Allow); err != nil {
+		if err := oc.updateACLLoggingForPolicy(np, np.portGroupName, nsInfo.aclLogging.Allow); err != nil {
 			klog.Warningf(err.Error())
 		} else {
 			klog.Infof("Policy %s: ACL logging setting updated to deny=%s allow=%s",
@@ -1347,14 +1835,14 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 
 // buildNetworkPolicyACLs builds the ACLS associated with the 'gress policies
 // of the provided network policy.
-func (oc *Controller) buildNetworkPolicyACLs(np *networkPolicy, aclLogging string) []*nbdb.ACL {
+func (oc *Controller) buildNetworkPolicyACLs(np *networkPolicy, portGropName, aclLogging string) []*nbdb.ACL {
 	acls := []*nbdb.ACL{}
 	for _, gp := range np.ingressPolicies {
-		acl := gp.buildLocalPodACLs(np.portGroupName, aclLogging)
+		acl := gp.buildLocalPodACLs(portGropName, aclLogging)
 		acls = append(acls, acl...)
 	}
 	for _, gp := range np.egressPolicies {
-		acl := gp.buildLocalPodACLs(np.portGroupName, aclLogging)
+		acl := gp.buildLocalPodACLs(portGropName, aclLogging)
 		acls = append(acls, acl...)
 	}
 
@@ -1377,7 +1865,7 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 		}
 
 		if err := oc.destroyNetworkPolicy(np, false); err != nil {
-			return fmt.Errorf("failed to destroy network policy: %s/%s", policy.Namespace, policy.Name)
+			return fmt.Errorf("failed to destroy network policy: %s/%s: %v", policy.Namespace, policy.Name, err)
 		}
 		return nil
 	}
@@ -1399,7 +1887,7 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 	}
 	isLastPolicyInNamespace := len(nsInfo.networkPolicies) == expectedLastPolicyNum
 	if err := oc.destroyNetworkPolicy(np, isLastPolicyInNamespace); err != nil {
-		return fmt.Errorf("failed to destroy network policy: %s/%s", policy.Namespace, policy.Name)
+		return fmt.Errorf("failed to destroy network policy: %s/%s: %v", policy.Namespace, policy.Name, err)
 	}
 
 	delete(nsInfo.networkPolicies, policy.Name)
@@ -1415,29 +1903,56 @@ func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, lastPolicy bool) e
 	np.deleted = true
 	oc.shutdownHandlers(np)
 
-	ports := []*lpInfo{}
-	np.localPods.Range(func(_, value interface{}) bool {
-		portInfo := value.(*lpInfo)
-		ports = append(ports, portInfo)
-		return true
-	})
-
 	var err error
 	ingressPGName := defaultDenyPortGroup(np.namespace, ingressDefaultDenySuffix)
 	egressPGName := defaultDenyPortGroup(np.namespace, egressDefaultDenySuffix)
 
-	ingressDenyPorts, egressDenyPorts := oc.localPodDelDefaultDeny(np, ports...)
-	defer func() {
-		// In case of error, undo localPodDelDefaultDeny() and restore lspIngressDenyCache/lspEgressDenyCache refcnt.
-		// Deletion will be retried.
-		if err != nil {
-			oc.localPodAddDefaultDeny(np.policy, ports...)
-		}
-	}()
-
 	ops := []ovsdb.Operation{}
-	// we haven't deleted our np from the namespace yet so there should be 1 policy
-	// if there are no more policies left on the namespace
+	if np.sharePortGroupName != "" {
+		err = oc.deleteSharedPolicy(np)
+		if err != nil {
+			return err
+		}
+	} else {
+		ports := []*lpInfo{}
+		np.localPods.Range(func(_, value interface{}) bool {
+			portInfo := value.(*lpInfo)
+			ports = append(ports, portInfo)
+			return true
+		})
+
+		ingressDenyPorts, egressDenyPorts := oc.localPodDelDefaultDeny(np, ports...)
+		defer func() {
+			// In case of error, undo localPodDelDefaultDeny() and restore lspIngressDenyCache/lspEgressDenyCache refcnt.
+			// Deletion will be retried.
+			if err != nil {
+				oc.localPodAddDefaultDeny(np.policy, ports...)
+			}
+		}()
+
+		// we haven't deleted our np from the namespace yet so there should be 1 policy
+		// if there are no more policies left on the namespace
+		if !lastPolicy {
+			ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, ingressPGName, ingressDenyPorts...)
+			if err != nil {
+				return fmt.Errorf("failed to make ops for ingress port group: %s, for policy: %s/%s, to remove ports: %#v,"+
+					" error: %v", ingressPGName, np.namespace, np.name, ingressDenyPorts, err)
+			}
+			ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, egressPGName, egressDenyPorts...)
+			if err != nil {
+				return fmt.Errorf("failed to make ops for egress port group: %s, for policy: %s/%s, to remove ports: %#v,"+
+					" error: %v", egressPGName, np.namespace, np.name, egressDenyPorts, err)
+			}
+		}
+
+		// Delete the port group
+		ops, err = libovsdbops.DeletePortGroupsOps(oc.nbClient, ops, np.portGroupName)
+		if err != nil {
+			return fmt.Errorf("failed to make delete network policy port group ops, policy: %s/%s, group name: %s,"+
+				" error: %v", np.namespace, np.name, np.portGroupName, err)
+		}
+	}
+
 	if lastPolicy {
 		ops, err = libovsdbops.DeletePortGroupsOps(oc.nbClient, ops, ingressPGName)
 		if err != nil {
@@ -1449,24 +1964,6 @@ func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, lastPolicy bool) e
 			return fmt.Errorf("failed to make ops for delete egress port group: %s, for policy: %s/%s, error: %v",
 				egressPGName, np.namespace, np.name, err)
 		}
-	} else {
-		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, ingressPGName, ingressDenyPorts...)
-		if err != nil {
-			return fmt.Errorf("failed to make ops for ingress port group: %s, for policy: %s/%s, to remove ports: %#v,"+
-				" error: %v", ingressPGName, np.namespace, np.name, ingressDenyPorts, err)
-		}
-		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, egressPGName, egressDenyPorts...)
-		if err != nil {
-			return fmt.Errorf("failed to make ops for egress port group: %s, for policy: %s/%s, to remove ports: %#v,"+
-				" error: %v", egressPGName, np.namespace, np.name, egressDenyPorts, err)
-		}
-	}
-
-	// Delete the port group
-	ops, err = libovsdbops.DeletePortGroupsOps(oc.nbClient, ops, np.portGroupName)
-	if err != nil {
-		return fmt.Errorf("failed to make delete network policy port group ops, policy: %s/%s, group name: %s,"+
-			" error: %v", np.namespace, np.name, np.portGroupName, err)
 	}
 
 	recordOps, txOkCallBack, _, err := metrics.GetConfigDurationRecorder().AddOVN(oc.nbClient, "networkpolicy",
@@ -1698,4 +2195,8 @@ func (oc *Controller) shutdownHandlers(np *networkPolicy) {
 
 func getPolicyNamespacedName(policy *knet.NetworkPolicy) string {
 	return fmt.Sprintf("%v/%v", policy.Namespace, policy.Name)
+}
+
+func getNPNamespacedName(np *networkPolicy) string {
+	return fmt.Sprintf("%v/%v", np.namespace, np.name)
 }

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1288,7 +1288,7 @@ func (oc *Controller) createSharedNMPortGroup(policy *knet.NetworkPolicy, np *ne
 	// create shared portGroup
 	pgName := np.sharePortGroupName
 	pgHashName := hashedPortGroup(pgName)
-	ingressPG := libovsdbops.BuildPortGroup(pgHashName, pgName, nil, nil)
+	sharedPG := libovsdbops.BuildPortGroup(pgHashName, pgName, nil, nil)
 
 	spgInfo := &sharedPortGroupInfo{
 		pgName:           pgHashName,
@@ -1302,10 +1302,10 @@ func (oc *Controller) createSharedNMPortGroup(policy *knet.NetworkPolicy, np *ne
 	handleSharedPortGroupInitialSelectedPods := func(objs []interface{}) error {
 		selectedPods = objs
 		policyPorts := oc.processSharedPortGroupLocalPodSelectorSetPods(spgInfo, selectedPods...)
-		ingressPG.Ports = policyPorts
-		err := libovsdbops.CreateOrUpdatePortGroups(oc.nbClient, ingressPG)
+		sharedPG.Ports = policyPorts
+		err := libovsdbops.CreateOrUpdatePortGroups(oc.nbClient, sharedPG)
 		if err != nil {
-			return fmt.Errorf("failed to create port group %s: %v", ingressPG.Name, err)
+			return fmt.Errorf("failed to create port group %s: %v", sharedPG.Name, err)
 		}
 		return nil
 	}

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -89,7 +89,7 @@ const (
 	egressDenyPG  string = "egressDefaultDeny"
 )
 
-func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, ports []string, logSeverity nbdb.ACLSeverity, oldEgress bool) []libovsdb.TestData {
+func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, ports []string, logSeverity nbdb.ACLSeverity, oldEgress bool, supportSharedGroup bool) []libovsdb.TestData {
 	pgHash := hashedPortGroup(networkPolicy.Namespace)
 	shouldBeLogged := logSeverity != nbdb.ACLSeverityInfo
 	egressDirection := nbdb.ACLDirectionFromLport
@@ -165,8 +165,10 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 	ingressAllowACL.UUID = *ingressAllowACL.Name + "-ingressAllowACL-UUID"
 
 	lsps := []*nbdb.LogicalSwitchPort{}
-	for _, uuid := range ports {
-		lsps = append(lsps, &nbdb.LogicalSwitchPort{UUID: uuid})
+	if !supportSharedGroup || getSharedPortGroupName(networkPolicy) == "" {
+		for _, uuid := range ports {
+			lsps = append(lsps, &nbdb.LogicalSwitchPort{UUID: uuid})
+		}
 	}
 
 	egressDenyPG := libovsdbops.BuildPortGroup(
@@ -195,153 +197,291 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 	}
 }
 
-func (n kNetworkPolicy) getPolicyData(networkPolicy *knet.NetworkPolicy, policyPorts []string, peerNamespaces []string, tcpPeerPorts []int32, logSeverity nbdb.ACLSeverity, oldEgress bool) []libovsdb.TestData {
-	pgName := networkPolicy.Namespace + "_" + networkPolicy.Name
-	pgHash := hashedPortGroup(pgName)
-	acls := []*nbdb.ACL{}
-
-	shouldBeLogged := logSeverity != nbdb.ACLSeverityInfo
-	for i := range networkPolicy.Spec.Ingress {
-		aclName := networkPolicy.Namespace + "_" + networkPolicy.Name + "_" + strconv.Itoa(i)
-		policyType := string(knet.PolicyTypeIngress)
-		if peerNamespaces != nil {
-			ingressAsMatch := asMatch(append(peerNamespaces, getAddressSetName(networkPolicy.Namespace, networkPolicy.Name, knet.PolicyTypeIngress, i)))
-			acl := libovsdbops.BuildACL(
-				aclName,
-				nbdb.ACLDirectionToLport,
-				types.DefaultAllowPriority,
-				fmt.Sprintf("ip4.src == {%s} && outport == @%s", ingressAsMatch, pgHash),
-				nbdb.ACLActionAllowRelated,
-				types.OvnACLLoggingMeter,
-				logSeverity,
-				shouldBeLogged,
-				map[string]string{
-					l4MatchACLExtIdKey:     "None",
-					ipBlockCIDRACLExtIdKey: "false",
-					namespaceACLExtIdKey:   networkPolicy.Namespace,
-					policyACLExtIdKey:      networkPolicy.Name,
-					policyTypeACLExtIdKey:  policyType,
-					policyType + "_num":    strconv.Itoa(i),
-				},
-				nil,
-			)
-			acl.UUID = *acl.Name + "-ingressACL-UUID"
-			acls = append(acls, acl)
+func (n kNetworkPolicy) getPolicyData(networkPolicies []*knet.NetworkPolicy, policyPorts []string, peerNamespaces []string, tcpPeerPorts []int32, denyLogSeverity, allowLogSeverity nbdb.ACLSeverity, oldEgress bool, supportSharedGroup bool) []libovsdb.TestData {
+	if len(networkPolicies) == 0 {
+		return []libovsdb.TestData{}
+	}
+	type pgArgType struct {
+		hashName         string
+		name             string
+		acls             []*nbdb.ACL
+		lspEgressRefCnt  int
+		lspIngressRefCnt int
+	}
+	pgArgMap := map[string]*pgArgType{}
+	for _, networkPolicy := range networkPolicies {
+		pgName := networkPolicy.Namespace + "_" + networkPolicy.Name
+		sharedPortGroupName := ""
+		if supportSharedGroup {
+			sharedPortGroupName = getSharedPortGroupName(networkPolicy)
 		}
-		for _, v := range tcpPeerPorts {
-			acl := libovsdbops.BuildACL(
-				aclName,
-				nbdb.ACLDirectionToLport,
-				types.DefaultAllowPriority,
-				fmt.Sprintf("ip4 && tcp && tcp.dst==%d && outport == @%s", v, pgHash),
-				nbdb.ACLActionAllowRelated,
-				types.OvnACLLoggingMeter,
-				logSeverity,
-				shouldBeLogged,
-				map[string]string{
-					l4MatchACLExtIdKey:     fmt.Sprintf("tcp && tcp.dst==%d", v),
-					ipBlockCIDRACLExtIdKey: "false",
-					namespaceACLExtIdKey:   networkPolicy.Namespace,
-					policyACLExtIdKey:      networkPolicy.Name,
-					policyTypeACLExtIdKey:  policyType,
-					policyType + "_num":    strconv.Itoa(i),
-				},
-				nil,
-			)
-			acl.UUID = fmt.Sprintf("%s-ingressACL-port_%d-UUID", *acl.Name, v)
-			acls = append(acls, acl)
+		if sharedPortGroupName != "" {
+			pgName = sharedPortGroupName
+		}
+		pgHash := hashedPortGroup(pgName)
+		pgArg, ok := pgArgMap[pgHash]
+		if !ok {
+			pgArg = &pgArgType{pgHash, pgName, []*nbdb.ACL{}, 0, 0}
+			pgArgMap[pgHash] = pgArg
+		}
+		if sharedPortGroupName != "" {
+			egressAcls, ingressAcls := n.getSharedNMDefaultDenyAcls(networkPolicy, nil, denyLogSeverity, false)
+			if !(len(networkPolicy.Spec.PolicyTypes) == 1 && networkPolicy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress) {
+				if pgArg.lspEgressRefCnt == 0 {
+					pgArg.acls = append(pgArg.acls, ingressAcls...)
+				}
+				pgArg.lspEgressRefCnt++
+			}
+			if (len(networkPolicy.Spec.PolicyTypes) == 1 && networkPolicy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress) ||
+				len(networkPolicy.Spec.Egress) > 0 || len(networkPolicy.Spec.PolicyTypes) == 2 {
+				if pgArg.lspIngressRefCnt == 0 {
+					pgArg.acls = append(pgArg.acls, egressAcls...)
+				}
+				pgArg.lspIngressRefCnt++
+			}
+		}
+
+		shouldBeLogged := allowLogSeverity != nbdb.ACLSeverityInfo
+		for i := range networkPolicy.Spec.Ingress {
+			aclName := networkPolicy.Namespace + "_" + networkPolicy.Name + "_" + strconv.Itoa(i)
+			policyType := string(knet.PolicyTypeIngress)
+			if peerNamespaces != nil {
+				ingressAsMatch := asMatch(append(peerNamespaces, getAddressSetName(networkPolicy.Namespace, networkPolicy.Name, knet.PolicyTypeIngress, i)))
+				acl := libovsdbops.BuildACL(
+					aclName,
+					nbdb.ACLDirectionToLport,
+					types.DefaultAllowPriority,
+					fmt.Sprintf("ip4.src == {%s} && outport == @%s", ingressAsMatch, pgHash),
+					nbdb.ACLActionAllowRelated,
+					types.OvnACLLoggingMeter,
+					allowLogSeverity,
+					shouldBeLogged,
+					map[string]string{
+						l4MatchACLExtIdKey:     "None",
+						ipBlockCIDRACLExtIdKey: "false",
+						namespaceACLExtIdKey:   networkPolicy.Namespace,
+						policyACLExtIdKey:      networkPolicy.Name,
+						policyTypeACLExtIdKey:  policyType,
+						policyType + "_num":    strconv.Itoa(i),
+					},
+					nil,
+				)
+				acl.UUID = *acl.Name + "-ingressACL-UUID"
+				pgArg.acls = append(pgArg.acls, acl)
+			}
+			for _, v := range tcpPeerPorts {
+				acl := libovsdbops.BuildACL(
+					aclName,
+					nbdb.ACLDirectionToLport,
+					types.DefaultAllowPriority,
+					fmt.Sprintf("ip4 && tcp && tcp.dst==%d && outport == @%s", v, pgHash),
+					nbdb.ACLActionAllowRelated,
+					types.OvnACLLoggingMeter,
+					allowLogSeverity,
+					shouldBeLogged,
+					map[string]string{
+						l4MatchACLExtIdKey:     fmt.Sprintf("tcp && tcp.dst==%d", v),
+						ipBlockCIDRACLExtIdKey: "false",
+						namespaceACLExtIdKey:   networkPolicy.Namespace,
+						policyACLExtIdKey:      networkPolicy.Name,
+						policyTypeACLExtIdKey:  policyType,
+						policyType + "_num":    strconv.Itoa(i),
+					},
+					nil,
+				)
+				acl.UUID = fmt.Sprintf("%s-ingressACL-port_%d-UUID", *acl.Name, v)
+				pgArg.acls = append(pgArg.acls, acl)
+			}
+		}
+
+		for i := range networkPolicy.Spec.Egress {
+			direction := nbdb.ACLDirectionFromLport
+			options := map[string]string{
+				"apply-after-lb": "true",
+			}
+			if oldEgress {
+				direction = nbdb.ACLDirectionToLport
+				options = map[string]string{}
+			}
+			aclName := networkPolicy.Namespace + "_" + networkPolicy.Name + "_" + strconv.Itoa(i)
+			policyType := string(knet.PolicyTypeEgress)
+			if peerNamespaces != nil {
+				egressAsMatch := asMatch(append(peerNamespaces, getAddressSetName(networkPolicy.Namespace, networkPolicy.Name, knet.PolicyTypeEgress, i)))
+				acl := libovsdbops.BuildACL(
+					aclName,
+					direction,
+					types.DefaultAllowPriority,
+					fmt.Sprintf("ip4.dst == {%s} && inport == @%s", egressAsMatch, pgHash),
+					nbdb.ACLActionAllowRelated,
+					types.OvnACLLoggingMeter,
+					allowLogSeverity,
+					shouldBeLogged,
+					map[string]string{
+						l4MatchACLExtIdKey:     "None",
+						ipBlockCIDRACLExtIdKey: "false",
+						namespaceACLExtIdKey:   networkPolicy.Namespace,
+						policyACLExtIdKey:      networkPolicy.Name,
+						policyTypeACLExtIdKey:  policyType,
+						policyType + "_num":    strconv.Itoa(i),
+					},
+					options,
+				)
+				acl.UUID = *acl.Name + "-egressACL-UUID"
+				pgArg.acls = append(pgArg.acls, acl)
+			}
+			for _, v := range tcpPeerPorts {
+				acl := libovsdbops.BuildACL(
+					aclName,
+					direction,
+					types.DefaultAllowPriority,
+					fmt.Sprintf("ip4 && tcp && tcp.dst==%d && inport == @%s", v, pgHash),
+					nbdb.ACLActionAllowRelated,
+					types.OvnACLLoggingMeter,
+					allowLogSeverity,
+					shouldBeLogged,
+					map[string]string{
+						l4MatchACLExtIdKey:     fmt.Sprintf("tcp && tcp.dst==%d", v),
+						ipBlockCIDRACLExtIdKey: "false",
+						namespaceACLExtIdKey:   networkPolicy.Namespace,
+						policyACLExtIdKey:      networkPolicy.Name,
+						policyTypeACLExtIdKey:  policyType,
+						policyType + "_num":    strconv.Itoa(i),
+					},
+					map[string]string{
+						"apply-after-lb": "true",
+					},
+				)
+				acl.UUID = fmt.Sprintf("%s-egressACL-port_%d-UUID", *acl.Name, v)
+				pgArg.acls = append(pgArg.acls, acl)
+			}
 		}
 	}
-
-	for i := range networkPolicy.Spec.Egress {
-		direction := nbdb.ACLDirectionFromLport
-		options := map[string]string{
-			"apply-after-lb": "true",
-		}
-		if oldEgress {
-			direction = nbdb.ACLDirectionToLport
-			options = map[string]string{}
-		}
-		aclName := networkPolicy.Namespace + "_" + networkPolicy.Name + "_" + strconv.Itoa(i)
-		policyType := string(knet.PolicyTypeEgress)
-		if peerNamespaces != nil {
-			egressAsMatch := asMatch(append(peerNamespaces, getAddressSetName(networkPolicy.Namespace, networkPolicy.Name, knet.PolicyTypeEgress, i)))
-			acl := libovsdbops.BuildACL(
-				aclName,
-				direction,
-				types.DefaultAllowPriority,
-				fmt.Sprintf("ip4.dst == {%s} && inport == @%s", egressAsMatch, pgHash),
-				nbdb.ACLActionAllowRelated,
-				types.OvnACLLoggingMeter,
-				logSeverity,
-				shouldBeLogged,
-				map[string]string{
-					l4MatchACLExtIdKey:     "None",
-					ipBlockCIDRACLExtIdKey: "false",
-					namespaceACLExtIdKey:   networkPolicy.Namespace,
-					policyACLExtIdKey:      networkPolicy.Name,
-					policyTypeACLExtIdKey:  policyType,
-					policyType + "_num":    strconv.Itoa(i),
-				},
-				options,
-			)
-			acl.UUID = *acl.Name + "-egressACL-UUID"
-			acls = append(acls, acl)
-		}
-		for _, v := range tcpPeerPorts {
-			acl := libovsdbops.BuildACL(
-				aclName,
-				direction,
-				types.DefaultAllowPriority,
-				fmt.Sprintf("ip4 && tcp && tcp.dst==%d && inport == @%s", v, pgHash),
-				nbdb.ACLActionAllowRelated,
-				types.OvnACLLoggingMeter,
-				logSeverity,
-				shouldBeLogged,
-				map[string]string{
-					l4MatchACLExtIdKey:     fmt.Sprintf("tcp && tcp.dst==%d", v),
-					ipBlockCIDRACLExtIdKey: "false",
-					namespaceACLExtIdKey:   networkPolicy.Namespace,
-					policyACLExtIdKey:      networkPolicy.Name,
-					policyTypeACLExtIdKey:  policyType,
-					policyType + "_num":    strconv.Itoa(i),
-				},
-				options,
-			)
-			acl.UUID = fmt.Sprintf("%s-egressACL-port_%d-UUID", *acl.Name, v)
-			acls = append(acls, acl)
-		}
-	}
-
-	lsps := []*nbdb.LogicalSwitchPort{}
-	for _, uuid := range policyPorts {
-		lsps = append(lsps, &nbdb.LogicalSwitchPort{UUID: uuid})
-	}
-
-	pg := libovsdbops.BuildPortGroup(
-		pgHash,
-		pgName,
-		lsps,
-		acls,
-	)
-	pg.UUID = pg.Name + "-UUID"
 
 	data := []libovsdb.TestData{}
-	for _, acl := range acls {
-		data = append(data, acl)
+	for _, pgArg := range pgArgMap {
+		lsps := []*nbdb.LogicalSwitchPort{}
+		for _, uuid := range policyPorts {
+			lsps = append(lsps, &nbdb.LogicalSwitchPort{UUID: uuid})
+		}
+
+		pg := libovsdbops.BuildPortGroup(
+			pgArg.hashName,
+			pgArg.name,
+			lsps,
+			pgArg.acls,
+		)
+		pg.UUID = pg.Name + "-UUID"
+
+		for _, acl := range pgArg.acls {
+			data = append(data, acl)
+		}
+		data = append(data, pg)
 	}
-	data = append(data, pg)
 	return data
 }
 
-func (n kNetworkPolicy) generateExpectedACLDataForFirstPolicyOnNamespace(policy knet.NetworkPolicy, loggingSeverity nbdb.ACLSeverity) []libovsdb.TestData {
+func aclsString(acls []*nbdb.ACL) string {
+	string := ""
+	for i, acl := range acls {
+		string = string + fmt.Sprintf("    acl %d ", i) + fmt.Sprintf("%s: ", *(acl.Name)) + fmt.Sprintf("%v\n", *acl)
+	}
+	return string
+}
+
+func (n kNetworkPolicy) getSharedNMDefaultDenyAcls(np *knet.NetworkPolicy, ports []string, logSeverity nbdb.ACLSeverity, oldEgress bool) ([]*nbdb.ACL, []*nbdb.ACL) {
+	direction := nbdb.ACLDirectionFromLport
+	options := map[string]string{
+		"apply-after-lb": "true",
+	}
+	if oldEgress {
+		direction = nbdb.ACLDirectionToLport
+		options = map[string]string{}
+	}
+	egressAcls := []*nbdb.ACL{}
+	ingressAcls := []*nbdb.ACL{}
+	pgName := getSharedPortGroupName(np)
+	pgHashName := hashedPortGroup(pgName)
+	shouldBeLogged := logSeverity != nbdb.ACLSeverityInfo
+	egressDenyACL := libovsdbops.BuildACL(
+		pgName+"_"+"egressDefaultDeny",
+		direction,
+		types.DefaultDenyPriority,
+		"inport == @"+pgHashName,
+		nbdb.ACLActionDrop,
+		types.OvnACLLoggingMeter,
+		logSeverity,
+		shouldBeLogged,
+		map[string]string{
+			defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress),
+		},
+		options,
+	)
+	egressDenyACL.UUID = *egressDenyACL.Name + "-egressDenyACL-UUID"
+	egressAcls = append(egressAcls, egressDenyACL)
+
+	egressAllowACL := libovsdbops.BuildACL(
+		pgName+"_ARPallowPolicy",
+		direction,
+		types.DefaultAllowPriority,
+		"inport == @"+pgHashName+" && (arp || nd)",
+		nbdb.ACLActionAllow,
+		types.OvnACLLoggingMeter,
+		nbdb.ACLSeverityInfo,
+		false,
+		map[string]string{
+			defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeEgress),
+		},
+		map[string]string{
+			"apply-after-lb": "true",
+		},
+	)
+	egressAllowACL.UUID = *egressAllowACL.Name + "-egressAllowACL-UUID"
+	egressAcls = append(egressAcls, egressAllowACL)
+
+	ingressDenyACL := libovsdbops.BuildACL(
+		pgName+"_"+"ingressDefaultDeny",
+		nbdb.ACLDirectionToLport,
+		types.DefaultDenyPriority,
+		"outport == @"+pgHashName,
+		nbdb.ACLActionDrop,
+		types.OvnACLLoggingMeter,
+		logSeverity,
+		shouldBeLogged,
+		map[string]string{
+			defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeIngress),
+		},
+		nil,
+	)
+	ingressDenyACL.UUID = *ingressDenyACL.Name + "-ingressDenyACL-UUID"
+	ingressAcls = append(ingressAcls, ingressDenyACL)
+
+	ingressAllowACL := libovsdbops.BuildACL(
+		pgName+"_ARPallowPolicy",
+		nbdb.ACLDirectionToLport,
+		types.DefaultAllowPriority,
+		"outport == @"+pgHashName+" && (arp || nd)",
+		nbdb.ACLActionAllow,
+		types.OvnACLLoggingMeter,
+		nbdb.ACLSeverityInfo,
+		false,
+		map[string]string{
+			defaultDenyPolicyTypeACLExtIdKey: string(knet.PolicyTypeIngress),
+		},
+		nil,
+	)
+	ingressAllowACL.UUID = *ingressAllowACL.Name + "-ingressAllowACL-UUID"
+	ingressAcls = append(ingressAcls, ingressAllowACL)
+	return egressAcls, ingressAcls
+}
+
+func (n kNetworkPolicy) generateExpectedACLDataForFirstPolicyOnNamespace(policy knet.NetworkPolicy, denyLoggingSeverity, allowLoggingSeverity nbdb.ACLSeverity) []libovsdb.TestData {
 	var expectedData []libovsdb.TestData
 	expectedData = append(
 		expectedData,
-		n.getDefaultDenyData(&policy, nil, loggingSeverity, false)...)
+		n.getDefaultDenyData(&policy, nil, denyLoggingSeverity, false, true)...)
 	return append(
 		expectedData,
-		n.getPolicyData(&policy, nil, []string{}, nil, loggingSeverity, false)...)
+		n.getPolicyData([]*knet.NetworkPolicy{&policy}, nil, []string{}, nil, denyLoggingSeverity, allowLoggingSeverity, false, true)...)
 }
 
 func getAddressSetName(namespace, name string, policyType knet.PolicyType, idx int) string {
@@ -790,8 +930,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				npTest := kNetworkPolicy{}
-				gressPolicyExpectedData := npTest.getPolicyData(networkPolicy, nil, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -832,6 +972,100 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("upgrading a networkPolicy with shared port group", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
+				networkPolicy := newNetworkPolicy("networkpolicy1", namespace1.Name,
+					metav1.LabelSelector{},
+					[]knet.NetworkPolicyIngressRule{
+						{
+							From: []knet.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"name": namespace2.Name,
+										},
+									},
+								},
+							},
+						},
+					},
+					[]knet.NetworkPolicyEgressRule{
+						{
+							To: []knet.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"name": namespace2.Name,
+										},
+									},
+								},
+							},
+						},
+					})
+				npTest := kNetworkPolicy{}
+				lr := &nbdb.LogicalRouter{
+					UUID: types.OVNClusterRouter + "-UUID",
+					Name: types.OVNClusterRouter,
+					ExternalIDs: map[string]string{
+						"k8s-cluster-router":   "yes",
+						"k8s-ovn-topo-version": strconv.Itoa(types.OvnRoutingViaHostTopoVersion),
+					},
+					Options: map[string]string{
+						"always_learn_from_arp_request": "false",
+					},
+				}
+				gressPolicyInitialData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, false)
+				defaultDenyInitialData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false, false)
+				initialData := []libovsdb.TestData{}
+				initialData = append(initialData, lr)
+				initialData = append(initialData, gressPolicyInitialData...)
+				initialData = append(initialData, defaultDenyInitialData...)
+				fakeOvn.startWithDBSetup(
+					libovsdb.TestSetup{
+						NBData: initialData,
+					},
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespace1,
+							namespace2,
+						},
+					},
+					&knet.NetworkPolicyList{
+						Items: []knet.NetworkPolicy{
+							*networkPolicy,
+						},
+					},
+				)
+
+				err := fakeOvn.controller.WatchNamespaces()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOvn.controller.WatchNetworkPolicy()
+
+				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
+				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName2)
+
+				eventuallyExpectEmptyAddressSetsExist(fakeOvn, networkPolicy)
+
+				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				expectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false, true)
+				expectedData = append(expectedData, defaultDenyExpectedData...)
+				expectedData = append(expectedData, lr)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		})
+
 		ginkgo.It("reconciles an egress networkPolicy updating existing ACLs", func() {
 			app.Action = func(ctx *cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
@@ -865,9 +1099,21 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 				npTest := kNetworkPolicy{}
-				gressPolicyInitialData := npTest.getPolicyData(networkPolicy, nil, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, true)
-				defaultDenyInitialData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, true)
+				gressPolicyInitialData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, true, false)
+				defaultDenyInitialData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, true, false)
 				initialData := []libovsdb.TestData{}
+				lr := &nbdb.LogicalRouter{
+					UUID: types.OVNClusterRouter + "-UUID",
+					Name: types.OVNClusterRouter,
+					ExternalIDs: map[string]string{
+						"k8s-cluster-router":   "yes",
+						"k8s-ovn-topo-version": strconv.Itoa(types.OvnRoutingViaHostTopoVersion),
+					},
+					Options: map[string]string{
+						"always_learn_from_arp_request": "false",
+					},
+				}
+				initialData = append(initialData, lr)
 				initialData = append(initialData, gressPolicyInitialData...)
 				initialData = append(initialData, defaultDenyInitialData...)
 				fakeOvn.startWithDBSetup(
@@ -889,7 +1135,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				err := fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				fakeOvn.controller.syncNetworkPolicies([]interface{}{networkPolicy})
+				fakeOvn.controller.WatchNetworkPolicy()
 
 				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
 				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName2)
@@ -899,9 +1145,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				expectedData := npTest.getPolicyData(networkPolicy, nil, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false)
+				expectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false, true)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
+				expectedData = append(expectedData, lr)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
 
 				return nil
@@ -947,8 +1194,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				npTest := kNetworkPolicy{}
-				gressPolicyInitialData := npTest.getPolicyData(networkPolicy, nil, []string{}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyInitialData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false)
+				gressPolicyInitialData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyInitialData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false, true)
 				initialData := []libovsdb.TestData{}
 				initialData = append(initialData, gressPolicyInitialData...)
 				initialData = append(initialData, defaultDenyInitialData...)
@@ -982,7 +1229,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				expectedData := npTest.getPolicyData(networkPolicy, nil, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, false)
+				expectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
 				expectedData = append(expectedData, defaultDenyInitialData...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
 
@@ -1038,8 +1285,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				npTest := kNetworkPolicy{}
-				gressPolicyExpectedData := npTest.getPolicyData(networkPolicy, []string{nPodTest.portUUID}, []string{}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, []string{nPodTest.portUUID}, []string{}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -1138,8 +1385,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				npTest := kNetworkPolicy{}
-				gressPolicyExpectedData := npTest.getPolicyData(networkPolicy, nil, []string{}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -1254,8 +1501,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				)
 
 				npTest := kNetworkPolicy{}
-				gressPolicy1ExpectedData := npTest.getPolicyData(networkPolicy, []string{nPodTest.portUUID}, nil, []int32{portNum}, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false)
+				gressPolicy1ExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, []string{nPodTest.portUUID}, nil, []int32{portNum}, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicy1ExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -1291,7 +1538,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Create(context.TODO(), networkPolicy2, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				gressPolicy2ExpectedData := npTest.getPolicyData(networkPolicy2, []string{nPodTest.portUUID}, nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo, false)
+				gressPolicy2ExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy2}, []string{nPodTest.portUUID}, nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
 				expectedDataWithPolicy2 := append(expectedData, gressPolicy2ExpectedData...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedDataWithPolicy2...))
 
@@ -1386,8 +1633,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				)
 
 				npTest := kNetworkPolicy{}
-				gressPolicy1ExpectedData := npTest.getPolicyData(networkPolicy, []string{nPodTest.portUUID}, nil, []int32{portNum}, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false)
+				gressPolicy1ExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, []string{nPodTest.portUUID}, nil, []int32{portNum}, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicy1ExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -1442,7 +1689,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.retryPods.setRetryObjWithNoBackoff(key)
 				fakeOvn.controller.retryNetworkPolicies.requestRetryObjs()
 
-				gressPolicy2ExpectedData := npTest.getPolicyData(networkPolicy2, []string{nPodTest.portUUID}, nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo, false)
+				gressPolicy2ExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy2}, []string{nPodTest.portUUID}, nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
 				expectedDataWithPolicy2 := append(expectedData, gressPolicy2ExpectedData...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedDataWithPolicy2...))
 				// check the cache no longer has the entry
@@ -1522,8 +1769,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				)
 
 				npTest := kNetworkPolicy{}
-				gressPolicy1ExpectedData := npTest.getPolicyData(networkPolicy, []string{nPodTest.portUUID}, nil, []int32{portNum}, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false)
+				gressPolicy1ExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, []string{nPodTest.portUUID}, nil, []int32{portNum}, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicy1ExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -1586,8 +1833,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Create(context.TODO(), networkPolicy2, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				gressPolicy2ExpectedData := npTest.getPolicyData(networkPolicy2, []string{nPodTest.portUUID}, nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData2 := npTest.getDefaultDenyData(networkPolicy2, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false)
+				gressPolicy2ExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy2}, []string{nPodTest.portUUID}, nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData2 := npTest.getDefaultDenyData(networkPolicy2, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false, true)
 
 				expectedData = []libovsdb.TestData{}
 				// FIXME(trozet): libovsdb server doesn't remove referenced ACLs to PG when deleting the PG
@@ -1925,11 +2172,11 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				npTest := kNetworkPolicy{}
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)
-				gressPolicy1ExpectedData := npTest.getPolicyData(networkPolicy1, []string{nPodTest.portUUID}, nil, []int32{portNum}, nbdb.ACLSeverityInfo, false)
-				defaultDeny1ExpectedData := npTest.getDefaultDenyData(networkPolicy1, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false)
+				gressPolicy1ExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy1}, []string{nPodTest.portUUID}, nil, []int32{portNum}, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDeny1ExpectedData := npTest.getDefaultDenyData(networkPolicy1, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false, true)
 				expectedData = append(expectedData, gressPolicy1ExpectedData...)
 				expectedData = append(expectedData, defaultDeny1ExpectedData...)
-				gressPolicy2ExpectedData := npTest.getPolicyData(networkPolicy2, []string{nPodTest.portUUID}, nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo, false)
+				gressPolicy2ExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy2}, []string{nPodTest.portUUID}, nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
 				expectedData = append(expectedData, gressPolicy2ExpectedData...)
 				egressOptions = map[string]string{
 					"apply-after-lb": "true",
@@ -2002,8 +2249,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				npTest := kNetworkPolicy{}
-				gressPolicyExpectedData := npTest.getPolicyData(networkPolicy, []string{nPodTest.portUUID}, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, []string{nPodTest.portUUID}, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -2039,7 +2286,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
 
 				expectedData = []libovsdb.TestData{}
-				gressPolicyExpectedData = npTest.getPolicyData(networkPolicy, []string{nPodTest.portUUID}, []string{}, nil, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData = npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, []string{nPodTest.portUUID}, []string{}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
 				expectedData = append(expectedData, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)
@@ -2090,8 +2337,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				npTest := kNetworkPolicy{}
-				gressPolicyExpectedData := npTest.getPolicyData(networkPolicy, nil, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{namespace2.Name}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -2123,7 +2370,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
 
 				expectedData = []libovsdb.TestData{}
-				gressPolicyExpectedData = npTest.getPolicyData(networkPolicy, nil, []string{}, nil, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData = npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
 				expectedData = append(expectedData, &nbdb.LogicalSwitch{
@@ -2186,8 +2433,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				npTest := kNetworkPolicy{}
-				gressPolicyExpectedData := npTest.getPolicyData(networkPolicy, []string{nPodTest.portUUID}, []string{}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, []string{nPodTest.portUUID}, []string{}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -2229,8 +2476,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				eventuallyExpectEmptyAddressSetsExist(fakeOvn, networkPolicy)
 				fakeOvn.asf.EventuallyExpectEmptyAddressSetExist(namespaceName1)
 
-				gressPolicyExpectedData = npTest.getPolicyData(networkPolicy, nil, []string{}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData = npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData = npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData = npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false, true)
 				expectedData = []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -2302,8 +2549,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				npTest := kNetworkPolicy{}
-				gressPolicyExpectedData := npTest.getPolicyData(networkPolicy, nil, []string{}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -2411,8 +2658,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				npTest := kNetworkPolicy{}
-				gressPolicyExpectedData := npTest.getPolicyData(networkPolicy, nil, []string{}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, nil, []string{}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, nil, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -2511,8 +2758,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				npTest := kNetworkPolicy{}
-				gressPolicyExpectedData := npTest.getPolicyData(networkPolicy, []string{nPodTest.portUUID}, []string{}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, []string{nPodTest.portUUID}, []string{}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -2551,7 +2798,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				eventuallyExpectNoAddressSets(fakeOvn, networkPolicy)
 
 				acls := []libovsdb.TestData{}
-				acls = append(acls, gressPolicyExpectedData[:len(gressPolicyExpectedData)-1]...)
+				//acls = append(acls, gressPolicyExpectedData[:len(gressPolicyExpectedData)-1]...)
 				acls = append(acls, defaultDenyExpectedData[:len(defaultDenyExpectedData)-2]...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(append(acls, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)))
 
@@ -2606,8 +2853,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					})
 
 				npTest := kNetworkPolicy{}
-				gressPolicyExpectedData := npTest.getPolicyData(networkPolicy, []string{nPodTest.portUUID}, []string{}, nil, nbdb.ACLSeverityInfo, false)
-				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false)
+				gressPolicyExpectedData := npTest.getPolicyData([]*knet.NetworkPolicy{networkPolicy}, []string{nPodTest.portUUID}, []string{}, nil, nbdb.ACLSeverityInfo, nbdb.ACLSeverityInfo, false, true)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo, false, true)
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
@@ -2645,6 +2892,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
 				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
 
+				ginkgo.By("inject transient problem, nbdb is down")
 				// inject transient problem, nbdb is down
 				fakeOvn.controller.nbClient.Close()
 				gomega.Eventually(func() bool {
@@ -2653,6 +2901,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Delete(context.TODO(), networkPolicy.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+				ginkgo.By("delete policy, sleep long enough for TransactWithRetry to fail, causing NP Add to fail")
 				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
 				time.Sleep(types.OVSDBTimeout + time.Second)
 				// check to see if the retry cache has an entry for this policy
@@ -2669,7 +2918,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				eventuallyExpectNoAddressSets(fakeOvn, networkPolicy)
 
 				acls := []libovsdb.TestData{}
-				acls = append(acls, gressPolicyExpectedData[:len(gressPolicyExpectedData)-1]...)
 				acls = append(acls, defaultDenyExpectedData[:len(defaultDenyExpectedData)-2]...)
 				gomega.Eventually(fakeOvn.controller.nbClient).Should(libovsdb.HaveData(append(acls, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)))
 
@@ -2809,7 +3057,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			}
 
 			provisionNetworkPolicy := func(namespaceName string, policy knet.NetworkPolicy) error {
-				ginkgo.By("Provisioning a new network policy")
+				ginkgo.By(fmt.Sprintf("Provisioning a new network policy %s/%s", policy.Namespace, policy.Name))
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(namespaceName).Create(context.TODO(), &policy, metav1.CreateOptions{})
 				return err
 			}
@@ -2826,33 +3074,33 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				ginkgo.By("Provisioning the system with an initial empty policy, we know deterministically the names of the default deny ACLs")
 				initialDenyAllPolicy := generateIngressEmptyPolicy()
-				initialExpectedData := npTest.generateExpectedACLDataForFirstPolicyOnNamespace(initialDenyAllPolicy, nbdb.ACLSeverityAlert)
+				initialExpectedData := npTest.generateExpectedACLDataForFirstPolicyOnNamespace(initialDenyAllPolicy, nbdb.ACLSeverityAlert, nbdb.ACLSeverityNotice)
 
 				app.Action = func(ctx *cli.Context) error {
 					setInitialOVNState(originalNamespace, initialDenyAllPolicy)
 					gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(initialExpectedData...))
 
-					var provisionedPolicies []libovsdb.TestData
+					policies := []*knet.NetworkPolicy{&initialDenyAllPolicy}
 					for i := range networkPolicies {
-						provisionedPolicies = append(
-							provisionedPolicies,
-							npTest.getPolicyData(&networkPolicies[i], nil, []string{}, nil, nbdb.ACLSeverityNotice, false)...)
+						policies = append(policies, &networkPolicies[i])
+					}
+					provisionedPolicies := npTest.getPolicyData(policies, nil, []string{}, nil, nbdb.ACLSeverityAlert, nbdb.ACLSeverityNotice, false, true)
+
+					for i := range networkPolicies {
 						gomega.Expect(provisionNetworkPolicy(networkPolicies[i].GetNamespace(), networkPolicies[i])).To(gomega.Succeed())
 					}
-					gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(append(initialExpectedData, provisionedPolicies...)))
+					defaultDenyExpectedData := npTest.getDefaultDenyData(&initialDenyAllPolicy, nil, nbdb.ACLSeverityAlert, false, true)
+					gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(append(defaultDenyExpectedData, provisionedPolicies...)))
 
 					desiredLogSeverity := nbdb.ACLSeverityDebug
 					gomega.Expect(
 						updateNamespaceACLLogSeverity(&originalNamespace, desiredLogSeverity, desiredLogSeverity)).To(gomega.Succeed(),
 						"should have managed to update the ACL logging severity within the namespace")
 
-					expectedDataAfterLoggingSeverityUpdate := npTest.generateExpectedACLDataForFirstPolicyOnNamespace(
-						initialDenyAllPolicy, desiredLogSeverity)
-					for i := range networkPolicies {
-						expectedDataAfterLoggingSeverityUpdate = append(
-							expectedDataAfterLoggingSeverityUpdate,
-							npTest.getPolicyData(&networkPolicies[i], nil, []string{}, nil, desiredLogSeverity, false)...)
-					}
+					expectedDataAfterLoggingSeverityUpdate := npTest.getDefaultDenyData(&initialDenyAllPolicy, nil, desiredLogSeverity, false, true)
+					expectedDataAfterLoggingSeverityUpdate = append(
+						expectedDataAfterLoggingSeverityUpdate,
+						npTest.getPolicyData(policies, nil, []string{}, nil, desiredLogSeverity, desiredLogSeverity, false, true)...)
 
 					gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedDataAfterLoggingSeverityUpdate...))
 					return nil
@@ -2880,8 +3128,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 					npTest := kNetworkPolicy{}
 					var expectedData []libovsdb.TestData
-					expectedData = append(expectedData, npTest.getPolicyData(&newPolicy, nil, []string{}, nil, desiredLogSeverity, false)...)
-					expectedData = append(expectedData, npTest.getDefaultDenyData(&newPolicy, nil, desiredLogSeverity, false)...)
+					expectedData = append(expectedData, npTest.getPolicyData([]*knet.NetworkPolicy{&newPolicy}, nil, []string{}, nil, desiredLogSeverity, desiredLogSeverity, false, true)...)
+					expectedData = append(expectedData, npTest.getDefaultDenyData(&newPolicy, nil, desiredLogSeverity, false, true)...)
 
 					gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
 					return nil

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -177,6 +177,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 		lsps,
 		[]*nbdb.ACL{egressDenyACL, egressAllowACL},
 	)
+	egressDenyPG.ExternalIDs["support_shared_port_group"] = "yes"
 	egressDenyPG.UUID = egressDenyPG.Name + "-UUID"
 
 	ingressDenyPG := libovsdbops.BuildPortGroup(
@@ -185,6 +186,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 		lsps,
 		[]*nbdb.ACL{ingressDenyACL, ingressAllowACL},
 	)
+	ingressDenyPG.ExternalIDs["support_shared_port_group"] = "yes"
 	ingressDenyPG.UUID = ingressDenyPG.Name + "-UUID"
 
 	return []libovsdb.TestData{
@@ -2076,6 +2078,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					nil,
 					[]*nbdb.ACL{leftOverACL1FromUpgrade},
 				)
+				testOnlyEgressDenyPG.ExternalIDs["support_shared_port_group"] = "yes"
 				testOnlyEgressDenyPG.UUID = testOnlyEgressDenyPG.Name + "-UUID"
 				// ACL2: leftover arp allow ACL ingress with old match (arp)
 				leftOverACL2FromUpgrade := libovsdbops.BuildACL(
@@ -2099,6 +2102,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					nil,
 					[]*nbdb.ACL{leftOverACL2FromUpgrade},
 				)
+				testOnlyIngressDenyPG.ExternalIDs["support_shared_port_group"] = "yes"
 				testOnlyIngressDenyPG.UUID = testOnlyIngressDenyPG.Name + "-UUID"
 
 				// ACL3: leftover default deny ACL egress with old name (namespace_policyname)

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -119,8 +119,7 @@ const (
 	OvnHostToSvcOFTopoVersion      = 3
 	OvnPortBindingTopoVersion      = 4
 	OvnRoutingViaHostTopoVersion   = 5
-	OvnSharePortGroupPolicyVersion = 6
-	OvnCurrentTopologyVersion      = OvnSharePortGroupPolicyVersion
+	OvnCurrentTopologyVersion      = OvnRoutingViaHostTopoVersion
 
 	// OVN-K8S annotation & taint constants
 	OvnK8sPrefix = "k8s.ovn.org"

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -119,7 +119,8 @@ const (
 	OvnHostToSvcOFTopoVersion      = 3
 	OvnPortBindingTopoVersion      = 4
 	OvnRoutingViaHostTopoVersion   = 5
-	OvnCurrentTopologyVersion      = OvnRoutingViaHostTopoVersion
+	OvnSharePortGroupPolicyVersion = 6
+	OvnCurrentTopologyVersion      = OvnSharePortGroupPolicyVersion
 
 	// OVN-K8S annotation & taint constants
 	OvnK8sPrefix = "k8s.ovn.org"


### PR DESCRIPTION
Today, port group is created for per network policy, even if they share
the same local pod selector. This means for the same pod that is
selected, its logical port will be added/deleted for multiple port
groups.

This commit is to add support of sharing of port_groups for multiple
network policies if they have the same local pod selector. To begin
with, we start with the policies whose local pod selector is empty.

Signed-off-by: Yun Zhou <yunz@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->